### PR TITLE
fix: restore header element and remove text content

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,8 +39,6 @@
     </button>
     <div class="container">
         <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
         </header>
 
         <div class="main-content">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -46,9 +46,11 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 1rem 2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {


### PR DESCRIPTION
## Summary
This PR fixes the missing header issue by restoring the header element visibility and removing all text content as requested.

## Changes
- Removed "Course Materials Assistant" heading from header
- Removed "Ask questions about courses, instructors, and content" subtitle
- Changed header CSS from `display:none` to visible with proper styling
- Theme toggle button functionality remains intact

Fixes #2

Generated with [Claude Code](https://claude.ai/code)